### PR TITLE
Fix SASUP api link

### DIFF
--- a/lib/src/up_menus_api.dart
+++ b/lib/src/up_menus_api.dart
@@ -45,7 +45,7 @@ class UPMenusApi {
   }
 
   Future<String> _get(String path) {
-    return _getImpl('$_baseUrl/$path');
+    return _getImpl(_baseUrl + path);
   }
 
   Future<String> _getImpl(String url) async {


### PR DESCRIPTION
The link for the SASUP API is malformed with a double '/' which causes a redirect slowing each request.

![image](https://github.com/user-attachments/assets/b6001e0e-c791-4997-b3de-58ce4d690c47)